### PR TITLE
Cider introduced an incompatible changes which resulted in an unusable Oook

### DIFF
--- a/oook.el
+++ b/oook.el
@@ -131,9 +131,8 @@ ERRBACK if specified must have following signature:
   (let* ((arg (oook-escape xquery))
          (form (format (oook-get-form) arg))
          (nrepl-callback (apply #'oook-make-nrepl-handler callback errback args))
-         (connection (cider-current-connection))
-         (session oook-session))
-    (nrepl-request:eval form nrepl-callback connection session)))
+         (connection (cider-current-connection)))
+    (nrepl-request:eval form nrepl-callback connection)))
 
 (defun oook-eval-sync (xquery)
   "Eval specified XQUERY string synchronously."
@@ -141,8 +140,7 @@ ERRBACK if specified must have following signature:
   (let* ((arg (oook-escape xquery))
          (form (format (oook-get-form) arg))
          (connection (cider-current-connection))
-         (session oook-session)
-         (response (nrepl-sync-request:eval form connection session))
+         (response (nrepl-sync-request:eval form connection))
          (value (nrepl-dict-get response "value")))
     (and value (read value))))
 


### PR DESCRIPTION
...as described in Issue 6 of Oook Selector by Florent Georges:
  https://github.com/xquery-mode/oook-selector/issues/6

This commit of cider introduced the incompatible change:
> commit efe15912fa66c4f7547e223d3b7ed7142572e059
> Author: dpsutton <dpsutton@users.noreply.github.com>
> Date:   Sun Jan 22 19:27:23 2017 -0600
>
>    Remove session from nrepl interaction (#1925)

See https://github.com/clojure-emacs/cider/commit/efe15912fa66c4f7547e223d3b7ed7142572e059
The signatures of functions nrepl-request:eval and nrepl-sync-request:eval
changed as the session parameter was removed.

Sadly, the fix is also an incompatible change for Oook, so now it requires
a version of Cider more recent than that commit (~2017-01-22).


That commit of cider also introduced the concept of a "tooling session"
in addition to the "standard session", see lines
https://github.com/clojure-emacs/cider/commit/efe15912fa66c4f7547e223d3b7ed7142572e059#diff-bc7f0008c444f0fbf63329a565cdf64fR795
and
https://github.com/clojure-emacs/cider/commit/efe15912fa66c4f7547e223d3b7ed7142572e059#diff-bc7f0008c444f0fbf63329a565cdf64fR909

I'm currently unsure if we should that "tooling session" as I didn't not
find more information on it in a quick search. Just form the name it
sound like a candidate, and might improve using Oook Selector in parallel
to general cider evaluation.